### PR TITLE
Replace any API endpoint [::] for localhost

### DIFF
--- a/src/Duracellko.PlanningPoker.Web/HttpClientSetupService.cs
+++ b/src/Duracellko.PlanningPoker.Web/HttpClientSetupService.cs
@@ -33,6 +33,7 @@ namespace Duracellko.PlanningPoker.Web
             {
                 address = address.Replace("*", "localhost", StringComparison.Ordinal);
                 address = address.Replace("+", "localhost", StringComparison.Ordinal);
+                address = address.Replace("[::]", "localhost", StringComparison.Ordinal);
             }
 
             _httpClient.BaseAddress = new Uri(address);


### PR DESCRIPTION
Replace any API endpoint [::] for localhost, when configuring base address for HttpClient in Server-side mode.