### PR TITLE
Application insights

### DIFF
--- a/azure-pipelines/azure-pipelines-build.yml
+++ b/azure-pipelines/azure-pipelines-build.yml
@@ -107,8 +107,8 @@ jobs:
     displayName: Zip web
     inputs:
       archiveType: zip
-      archiveFile: $(Build.StagingDirectory)\web\web.zip
-      rootFolderOrFile: $(Build.SourcesDirectory)\Build\web\$(BuildConfiguration)\netcoreapp2.1\publish
+      archiveFile: $(Build.StagingDirectory)/web/web.zip
+      rootFolderOrFile: $(Build.SourcesDirectory)/Build/web/$(BuildConfiguration)/netcoreapp2.1/publish
       includeRootFolder: false
       replaceExistingArchive: true
     condition: and(succeeded(), eq(variables['PublishArtifacts'], 'true'))
@@ -116,21 +116,21 @@ jobs:
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: web'
     inputs:
-      PathtoPublish: $(Build.StagingDirectory)\web
+      PathtoPublish: $(Build.StagingDirectory)/web
       ArtifactName: web
     condition: and(succeeded(), eq(variables['PublishArtifacts'], 'true'))
 
   - task: CopyFiles@2
     displayName: Copy screenshots
     inputs:
-      SourceFolder: $(Build.SourcesDirectory)\Build\bin\$(BuildConfiguration)\netcoreapp2.1\Screenshots
-      TargetFolder: $(Build.Build.StagingDirectory)\screenshots
+      SourceFolder: $(Build.SourcesDirectory)/Build/bin/$(BuildConfiguration)/netcoreapp2.1/Screenshots
+      TargetFolder: $(Build.Build.StagingDirectory)/screenshots
       CleanTargetFolder: true
     condition: and(succeeded(), eq(variables['RunEnd2EndTests'], 'true'))
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish artifact: screenshots'
     inputs:
-      PathtoPublish: $(Build.Build.StagingDirectory)\screenshots
+      PathtoPublish: $(Build.Build.StagingDirectory)/screenshots
       ArtifactName: screenshots
     condition: and(succeeded(), eq(variables['RunEnd2EndTests'], 'true'))

--- a/azure-pipelines/azure-pipelines-build.yml
+++ b/azure-pipelines/azure-pipelines-build.yml
@@ -9,7 +9,7 @@ jobs:
   displayName: PlanningPoker App
 
   pool:
-    vmImage: vs2017-win2016
+    vmImage: ubuntu-16.04
 
   workspace:
     clean: all

--- a/src/Duracellko.PlanningPoker.Web/Duracellko.PlanningPoker.Web.csproj
+++ b/src/Duracellko.PlanningPoker.Web/Duracellko.PlanningPoker.Web.csproj
@@ -14,6 +14,7 @@
   <Import Project="..\Duracellko.PlanningPoker.Shared\Duracellko.PlanningPoker.Shared.projitems" Label="Shared" />
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.7.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />

--- a/src/Duracellko.PlanningPoker.Web/Program.cs
+++ b/src/Duracellko.PlanningPoker.Web/Program.cs
@@ -12,6 +12,7 @@ namespace Duracellko.PlanningPoker.Web
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .UseApplicationInsights()
                 .UseStartup<Startup>();
     }
 }

--- a/test/Duracellko.PlanningPoker.E2ETest/PlanningPokerTest.cs
+++ b/test/Duracellko.PlanningPoker.E2ETest/PlanningPokerTest.cs
@@ -416,8 +416,8 @@ namespace Duracellko.PlanningPoker.E2ETest
         }
 
         [DataTestMethod]
-        [DataRow(false, BrowserType.Chrome, BrowserType.Firefox, DisplayName = "Client-side Chrome and Firefox")]
-        [DataRow(true, BrowserType.Chrome, BrowserType.Firefox, DisplayName = "Server-side Chrome and Firefox")]
+        [DataRow(false, BrowserType.Chrome, BrowserType.Chrome, DisplayName = "Client-side Chrome")]
+        [DataRow(true, BrowserType.Chrome, BrowserType.Chrome, DisplayName = "Server-side Chrome")]
         public async Task Cannot_Estimate_When_Joining_After_Start(bool serverSide, BrowserType browserType1, BrowserType browserType2)
         {
             Contexts.Add(new BrowserTestContext(

--- a/test/Duracellko.PlanningPoker.E2ETest/ScrumMasterTest.cs
+++ b/test/Duracellko.PlanningPoker.E2ETest/ScrumMasterTest.cs
@@ -11,9 +11,7 @@ namespace Duracellko.PlanningPoker.E2ETest
     {
         [DataTestMethod]
         [DataRow(false, BrowserType.Chrome, DisplayName = "Client-side Chrome")]
-        [DataRow(false, BrowserType.Firefox, DisplayName = "Client-side Firefox")]
         [DataRow(true, BrowserType.Chrome, DisplayName = "Server-side Chrome")]
-        [DataRow(true, BrowserType.Firefox, DisplayName = "Server-side Firefox")]
         public async Task ScrumMaster_Should_Be_Able_To_Estimate(bool serverSide, BrowserType browserType)
         {
             Contexts.Add(new BrowserTestContext(
@@ -85,9 +83,7 @@ namespace Duracellko.PlanningPoker.E2ETest
 
         [DataTestMethod]
         [DataRow(false, BrowserType.Chrome, DisplayName = "Client-side Chrome")]
-        [DataRow(false, BrowserType.Firefox, DisplayName = "Client-side Firefox")]
         [DataRow(true, BrowserType.Chrome, DisplayName = "Server-side Chrome")]
-        [DataRow(true, BrowserType.Firefox, DisplayName = "Server-side Firefox")]
         public async Task Shows_Error_When_Joining_Not_Existing_Team(bool serverSide, BrowserType browserType)
         {
             Contexts.Add(new BrowserTestContext(


### PR DESCRIPTION
Add Application Insights support.
Remove Firefox end-2-end tests, because Firefox Selenium driver gets stuck in random occasions.