### PR TITLE
Upgrade to .NET Core 3.0 final

### DIFF
--- a/src/Duracellko.PlanningPoker.Client/App.razor
+++ b/src/Duracellko.PlanningPoker.Client/App.razor
@@ -1,5 +1,10 @@
-﻿<Router AppAssembly="typeof(Program).Assembly">
-    <NotFoundContent>
-        <p>Specified page was not found. Please, verify that URL is correct.</p>
-    </NotFoundContent>
+﻿<Router AppAssembly="@typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(MainLayout)">
+            <p>Specified page was not found. Please, verify that URL is correct.</p>
+        </LayoutView>
+    </NotFound>
 </Router>

--- a/src/Duracellko.PlanningPoker.Client/Components/BusyIndicatorPanel.razor
+++ b/src/Duracellko.PlanningPoker.Client/Components/BusyIndicatorPanel.razor
@@ -2,7 +2,7 @@
 @inject UI.BusyIndicatorService _busyIndicatorService
 @inject IJSRuntime _jsRuntime
 
-<div @ref="busyIndicatorElement" @ref:suppressField class="modal" role="dialog" aria-hidden="true">
+<div @ref="busyIndicatorElement" class="modal" role="dialog" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered modal-sm">
         <div class="modal-content">
             <div class="modal-body">

--- a/src/Duracellko.PlanningPoker.Client/Components/GlobalMessagePanel.razor
+++ b/src/Duracellko.PlanningPoker.Client/Components/GlobalMessagePanel.razor
@@ -2,7 +2,7 @@
 @inject UI.MessageBoxService _messageBoxService
 @inject IJSRuntime _jsRuntime
 
-<div @ref="messageBoxElement" @ref:suppressField id="messageBox" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+<div @ref="messageBoxElement" id="messageBox" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">

--- a/src/Duracellko.PlanningPoker.Client/Components/NavBar.razor
+++ b/src/Duracellko.PlanningPoker.Client/Components/NavBar.razor
@@ -1,7 +1,7 @@
 ﻿@inherits ViewComponentBase
 @implements IDisposable
 @inject PlanningPokerController Controller
-@inject Microsoft.AspNetCore.Components.IUriHelper UriHelper
+@inject NavigationManager NavigationManager
 
 <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
     <div class="container">
@@ -45,7 +45,7 @@
         return TryRun(async () =>
         {
             await Controller.Disconnect();
-            UriHelper.NavigateTo("Index");
+            NavigationManager.NavigateTo("Index");
         });
     }
 

--- a/src/Duracellko.PlanningPoker.Client/Controllers/ControllerHelper.cs
+++ b/src/Duracellko.PlanningPoker.Client/Controllers/ControllerHelper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text.Encodings.Web;
+using Duracellko.PlanningPoker.Client.Service;
 using Duracellko.PlanningPoker.Service;
-using Microsoft.AspNetCore.Components;
 
 namespace Duracellko.PlanningPoker.Client.Controllers
 {
@@ -35,19 +35,19 @@ namespace Duracellko.PlanningPoker.Client.Controllers
         /// <summary>
         /// Opens PlanningPoker page with specified team name and member name.
         /// </summary>
-        /// <param name="uriHelper">Helper to navigate to URL.</param>
+        /// <param name="navigationManager">Helper to navigate to URL.</param>
         /// <param name="team">Scrum team name to include in URL.</param>
         /// <param name="member">Member name to include in URL.</param>
-        public static void OpenPlanningPokerPage(IUriHelper uriHelper, ScrumTeam team, string member)
+        public static void OpenPlanningPokerPage(INavigationManager navigationManager, ScrumTeam team, string member)
         {
-            if (uriHelper == null)
+            if (navigationManager == null)
             {
-                throw new ArgumentNullException(nameof(uriHelper));
+                throw new ArgumentNullException(nameof(navigationManager));
             }
 
             var urlEncoder = UrlEncoder.Default;
             var uri = $"PlanningPoker/{urlEncoder.Encode(team.Name)}/{urlEncoder.Encode(member)}";
-            uriHelper.NavigateTo(uri);
+            navigationManager.NavigateTo(uri);
         }
     }
 }

--- a/src/Duracellko.PlanningPoker.Client/Controllers/CreateTeamController.cs
+++ b/src/Duracellko.PlanningPoker.Client/Controllers/CreateTeamController.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Duracellko.PlanningPoker.Client.Service;
 using Duracellko.PlanningPoker.Client.UI;
 using Duracellko.PlanningPoker.Service;
-using Microsoft.AspNetCore.Components;
 
 namespace Duracellko.PlanningPoker.Client.Controllers
 {
@@ -16,7 +16,7 @@ namespace Duracellko.PlanningPoker.Client.Controllers
         private readonly IPlanningPokerInitializer _planningPokerInitializer;
         private readonly IMessageBoxService _messageBoxService;
         private readonly IBusyIndicatorService _busyIndicatorService;
-        private readonly IUriHelper _uriHelper;
+        private readonly INavigationManager _navigationManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CreateTeamController"/> class.
@@ -25,19 +25,19 @@ namespace Duracellko.PlanningPoker.Client.Controllers
         /// <param name="planningPokerInitializer">Objects that initialize new Planning Poker game.</param>
         /// <param name="messageBoxService">Service to display message to user.</param>
         /// <param name="busyIndicatorService">Service to display that operation is in progress.</param>
-        /// <param name="uriHelper">Service to navigate to specified URL.</param>
+        /// <param name="navigationManager">Service to navigate to specified URL.</param>
         public CreateTeamController(
             IPlanningPokerClient planningPokerService,
             IPlanningPokerInitializer planningPokerInitializer,
             IMessageBoxService messageBoxService,
             IBusyIndicatorService busyIndicatorService,
-            IUriHelper uriHelper)
+            INavigationManager navigationManager)
         {
             _planningPokerService = planningPokerService ?? throw new ArgumentNullException(nameof(planningPokerService));
             _planningPokerInitializer = planningPokerInitializer ?? throw new ArgumentNullException(nameof(planningPokerInitializer));
             _messageBoxService = messageBoxService ?? throw new ArgumentNullException(nameof(messageBoxService));
             _busyIndicatorService = busyIndicatorService ?? throw new ArgumentNullException(nameof(busyIndicatorService));
-            _uriHelper = uriHelper ?? throw new ArgumentNullException(nameof(uriHelper));
+            _navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Duracellko.PlanningPoker.Client.Controllers
                 if (team != null)
                 {
                     await _planningPokerInitializer.InitializeTeam(team, scrumMasterName);
-                    ControllerHelper.OpenPlanningPokerPage(_uriHelper, team, scrumMasterName);
+                    ControllerHelper.OpenPlanningPokerPage(_navigationManager, team, scrumMasterName);
                     return true;
                 }
             }

--- a/src/Duracellko.PlanningPoker.Client/Controllers/JoinTeamController.cs
+++ b/src/Duracellko.PlanningPoker.Client/Controllers/JoinTeamController.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Duracellko.PlanningPoker.Client.Service;
 using Duracellko.PlanningPoker.Client.UI;
 using Duracellko.PlanningPoker.Service;
-using Microsoft.AspNetCore.Components;
 
 namespace Duracellko.PlanningPoker.Client.Controllers
 {
@@ -20,7 +19,7 @@ namespace Duracellko.PlanningPoker.Client.Controllers
         private readonly IPlanningPokerInitializer _planningPokerInitializer;
         private readonly IMessageBoxService _messageBoxService;
         private readonly IBusyIndicatorService _busyIndicatorService;
-        private readonly IUriHelper _uriHelper;
+        private readonly INavigationManager _navigationManager;
         private readonly IMemberCredentialsStore _memberCredentialsStore;
 
         /// <summary>
@@ -30,21 +29,21 @@ namespace Duracellko.PlanningPoker.Client.Controllers
         /// <param name="planningPokerInitializer">Objects that initialize new Planning Poker game.</param>
         /// <param name="messageBoxService">Service to display message to user.</param>
         /// <param name="busyIndicatorService">Service to display that operation is in progress.</param>
-        /// <param name="uriHelper">Service to navigate to specified URL.</param>
+        /// <param name="navigationManager">Service to navigate to specified URL.</param>
         /// <param name="memberCredentialsStore">Service to save and load member credentials.</param>
         public JoinTeamController(
             IPlanningPokerClient planningPokerService,
             IPlanningPokerInitializer planningPokerInitializer,
             IMessageBoxService messageBoxService,
             IBusyIndicatorService busyIndicatorService,
-            IUriHelper uriHelper,
+            INavigationManager navigationManager,
             IMemberCredentialsStore memberCredentialsStore)
         {
             _planningPokerService = planningPokerService ?? throw new ArgumentNullException(nameof(planningPokerService));
             _planningPokerInitializer = planningPokerInitializer ?? throw new ArgumentNullException(nameof(planningPokerInitializer));
             _messageBoxService = messageBoxService ?? throw new ArgumentNullException(nameof(messageBoxService));
             _busyIndicatorService = busyIndicatorService ?? throw new ArgumentNullException(nameof(busyIndicatorService));
-            _uriHelper = uriHelper ?? throw new ArgumentNullException(nameof(uriHelper));
+            _navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
             _memberCredentialsStore = memberCredentialsStore ?? throw new ArgumentNullException(nameof(memberCredentialsStore));
         }
 
@@ -73,7 +72,7 @@ namespace Duracellko.PlanningPoker.Client.Controllers
                 if (team != null)
                 {
                     await _planningPokerInitializer.InitializeTeam(team, memberName);
-                    ControllerHelper.OpenPlanningPokerPage(_uriHelper, team, memberName);
+                    ControllerHelper.OpenPlanningPokerPage(_navigationManager, team, memberName);
                     return true;
                 }
             }
@@ -137,7 +136,7 @@ namespace Duracellko.PlanningPoker.Client.Controllers
                 if (reconnectTeamResult != null)
                 {
                     await _planningPokerInitializer.InitializeTeam(reconnectTeamResult, memberName);
-                    ControllerHelper.OpenPlanningPokerPage(_uriHelper, reconnectTeamResult.ScrumTeam, memberName);
+                    ControllerHelper.OpenPlanningPokerPage(_navigationManager, reconnectTeamResult.ScrumTeam, memberName);
                     return true;
                 }
             }

--- a/src/Duracellko.PlanningPoker.Client/Duracellko.PlanningPoker.Client.csproj
+++ b/src/Duracellko.PlanningPoker.Client/Duracellko.PlanningPoker.Client.csproj
@@ -16,10 +16,10 @@
   <Import Project="..\Duracellko.PlanningPoker.Shared\Duracellko.PlanningPoker.Shared.projitems" Label="Shared" />
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview8.19405.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview8.19405.7" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.0.0-preview8.19405.7" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.0.76" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview9.19465.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview9.19465.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.0.0-preview9.19465.2" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.0.96" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Duracellko.PlanningPoker.Client/Pages/PlanningPoker.razor
+++ b/src/Duracellko.PlanningPoker.Client/Pages/PlanningPoker.razor
@@ -3,7 +3,7 @@
 @implements IDisposable
 @inject PlanningPokerController Controller
 @inject MessageReceiver MessageReceiver
-@inject Microsoft.AspNetCore.Components.IUriHelper UriHelper
+@inject NavigationManager NavigationManager
 
 @if (Controller.ScrumTeam != null)
 {
@@ -49,7 +49,7 @@
                 uri = $"{uri}/{TeamName}/{MemberName}";
             }
 
-            UriHelper.NavigateTo(uri);
+            NavigationManager.NavigateTo(uri);
         }
         else
         {

--- a/src/Duracellko.PlanningPoker.Client/Pages/_Imports.razor
+++ b/src/Duracellko.PlanningPoker.Client/Pages/_Imports.razor
@@ -1,1 +1,0 @@
-﻿@layout MainLayout

--- a/src/Duracellko.PlanningPoker.Client/Service/AppNavigationManager.cs
+++ b/src/Duracellko.PlanningPoker.Client/Service/AppNavigationManager.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components;
+
+namespace Duracellko.PlanningPoker.Client.Service
+{
+    /// <summary>
+    /// Provides querying and mananging URI navigation.
+    /// </summary>
+    public class AppNavigationManager : INavigationManager
+    {
+        private readonly NavigationManager _navigationManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppNavigationManager"/> class.
+        /// </summary>
+        /// <param name="navigationManager">ASP.NET Core Components NavigationManager.</param>
+        public AppNavigationManager(NavigationManager navigationManager)
+        {
+            _navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
+        }
+
+        /// <summary>
+        /// Navigates to the specified URI.
+        /// </summary>
+        /// <param name="uri">The destination URI. This can be absolute, or relative to the base URI.</param>
+        [SuppressMessage("Design", "CA1054:Uri parameters should not be strings", Justification = "Follows NavigationManager from Blazor.")]
+        public void NavigateTo(string uri)
+        {
+            _navigationManager.NavigateTo(uri);
+        }
+    }
+}

--- a/src/Duracellko.PlanningPoker.Client/Service/INavigationManager.cs
+++ b/src/Duracellko.PlanningPoker.Client/Service/INavigationManager.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Duracellko.PlanningPoker.Client.Service
+{
+    /// <summary>
+    /// Provides an abstraction for querying and mananging URI navigation.
+    /// </summary>
+    public interface INavigationManager
+    {
+        /// <summary>
+        /// Navigates to the specified URI.
+        /// </summary>
+        /// <param name="uri">The destination URI. This can be absolute, or relative to the base URI.</param>
+        [SuppressMessage("Design", "CA1054:Uri parameters should not be strings", Justification = "Follows NavigationManager from Blazor.")]
+        void NavigateTo(string uri);
+    }
+}

--- a/src/Duracellko.PlanningPoker.Client/Startup.cs
+++ b/src/Duracellko.PlanningPoker.Client/Startup.cs
@@ -17,6 +17,7 @@ namespace Duracellko.PlanningPoker.Client
             services.AddScoped<IPlanningPokerClient, PlanningPokerClient>();
             services.AddScoped<IMemberCredentialsStore, MemberCredentialsStore>();
 
+            services.AddScoped<INavigationManager, AppNavigationManager>();
             services.AddScoped<MessageBoxService>();
             services.AddScoped<IMessageBoxService>(p => p.GetRequiredService<MessageBoxService>());
             services.AddScoped<BusyIndicatorService>();

--- a/src/Duracellko.PlanningPoker.Client/_Imports.razor
+++ b/src/Duracellko.PlanningPoker.Client/_Imports.razor
@@ -1,6 +1,7 @@
 @using System.Net.Http
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
 @using Duracellko.PlanningPoker.Client
 @using Duracellko.PlanningPoker.Client.Components

--- a/src/Duracellko.PlanningPoker.Shared/Duracellko.PlanningPoker.Shared.projitems
+++ b/src/Duracellko.PlanningPoker.Shared/Duracellko.PlanningPoker.Shared.projitems
@@ -27,7 +27,7 @@
     <OutputPath>..\..\Build\bin\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Duracellko.PlanningPoker.Web/Duracellko.PlanningPoker.Web.csproj
+++ b/src/Duracellko.PlanningPoker.Web/Duracellko.PlanningPoker.Web.csproj
@@ -14,9 +14,9 @@
   <Import Project="..\Duracellko.PlanningPoker.Shared\Duracellko.PlanningPoker.Shared.projitems" Label="Shared" />
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.0.0-preview8.19405.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview8.19405.7" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.0.0-preview9.19465.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Duracellko.PlanningPoker.Web/Pages/Home.cshtml
+++ b/src/Duracellko.PlanningPoker.Web/Pages/Home.cshtml
@@ -16,7 +16,16 @@
     <link href="Content/Site.css" rel="stylesheet" />
 </head>
 <body>
-    <app><span class="oi oi-loop-circular"></span> Loading...</app>
+    <app>
+        @if (Model.ClientConfiguration.UseServerSideBlazor)
+        {
+            @(await Html.RenderComponentAsync<Duracellko.PlanningPoker.Client.App>(RenderMode.Server))
+        }
+        else
+        {
+            <span class="oi oi-loop-circular"></span> <span>Loading...</span>
+        }
+    </app>
 
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="js/jquery.min.js"><\/script>')</script>

--- a/src/Duracellko.PlanningPoker.Web/Program.cs
+++ b/src/Duracellko.PlanningPoker.Web/Program.cs
@@ -14,7 +14,6 @@ namespace Duracellko.PlanningPoker.Web
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseApplicationInsights();
                     webBuilder.UseStartup<Startup>();
                 });
     }

--- a/src/Duracellko.PlanningPoker.Web/Startup.cs
+++ b/src/Duracellko.PlanningPoker.Web/Startup.cs
@@ -33,6 +33,7 @@ namespace Duracellko.PlanningPoker.Web
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddApplicationInsightsTelemetry();
             services.AddMvc()
                 .AddApplicationPart(typeof(PlanningPokerService).Assembly)
                 .AddMvcOptions(o => o.Conventions.Add(new PlanningPokerApplication()))
@@ -59,7 +60,7 @@ namespace Duracellko.PlanningPoker.Web
                 services.AddSingleton<PlanningPokerAzureNode>();
                 services.AddSingleton<IServiceBus, AzureServiceBus>();
                 services.AddSingleton<IMessageConverter, MessageConverter>();
-                services.AddScoped<IHostedService, AzurePlanningPokerNodeService>();
+                services.AddSingleton<IHostedService, AzurePlanningPokerNodeService>();
             }
             else
             {
@@ -76,7 +77,7 @@ namespace Duracellko.PlanningPoker.Web
                 services.AddSingleton<IScrumTeamRepository, EmptyScrumTeamRepository>();
             }
 
-            services.AddScoped<IHostedService, PlanningPokerCleanupService>();
+            services.AddSingleton<IHostedService, PlanningPokerCleanupService>();
 
             var clientConfiguration = new PlanningPokerClientConfiguration
             {
@@ -88,7 +89,7 @@ namespace Duracellko.PlanningPoker.Web
             {
                 services.AddServerSideBlazor();
                 services.AddSingleton<HttpClient>();
-                services.AddTransient<IHostedService, HttpClientSetupService>();
+                services.AddSingleton<IHostedService, HttpClientSetupService>();
 
                 // Register services used by client on server-side.
                 var blazorStartup = new Duracellko.PlanningPoker.Client.Startup();
@@ -124,7 +125,7 @@ namespace Duracellko.PlanningPoker.Web
                 endpoints.MapDefaultControllerRoute();
                 if (clientConfiguration.UseServerSideBlazor)
                 {
-                    endpoints.MapBlazorHub<Duracellko.PlanningPoker.Client.App>("app");
+                    endpoints.MapBlazorHub("app");
                 }
 
                 endpoints.MapFallbackToPage("/Home");

--- a/src/Duracellko.PlanningPoker.Web/Startup.cs
+++ b/src/Duracellko.PlanningPoker.Web/Startup.cs
@@ -125,7 +125,7 @@ namespace Duracellko.PlanningPoker.Web
                 endpoints.MapDefaultControllerRoute();
                 if (clientConfiguration.UseServerSideBlazor)
                 {
-                    endpoints.MapBlazorHub("app");
+                    endpoints.MapBlazorHub();
                 }
 
                 endpoints.MapFallbackToPage("/Home");

--- a/src/Duracellko.PlanningPoker/Duracellko.PlanningPoker.csproj
+++ b/src/Duracellko.PlanningPoker/Duracellko.PlanningPoker.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="AutoMapper" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0-preview8.19405.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.Reactive" Version="4.1.6" />
   </ItemGroup>

--- a/test/Duracellko.PlanningPoker.Azure.Test/Duracellko.PlanningPoker.Azure.Test.csproj
+++ b/test/Duracellko.PlanningPoker.Azure.Test/Duracellko.PlanningPoker.Azure.Test.csproj
@@ -10,10 +10,10 @@
   <Import Project="..\..\src\Duracellko.PlanningPoker.Shared\Duracellko.PlanningPoker.Shared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Duracellko.PlanningPoker.Client.Test/Components/ArrayRangeExtensions.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Components/ArrayRangeExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components.RenderTree;
 
 namespace Duracellko.PlanningPoker.Client.Test.Components
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "BL0006:Do not use RenderTree types", Justification = "Demonstration only.")]
     internal static class ArrayRangeExtensions
     {
         public static IEnumerable<T> AsEnumerable<T>(this ArrayRange<T> source)

--- a/test/Duracellko.PlanningPoker.Client.Test/Components/AssertFrame.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Components/AssertFrame.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Duracellko.PlanningPoker.Client.Test.Components
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "BL0006:Do not use RenderTree types", Justification = "Demonstration only.")]
     public static class AssertFrame
     {
         public static void Sequence(RenderTreeFrame frame, int? sequence = null)

--- a/test/Duracellko.PlanningPoker.Client.Test/Components/CapturedBatch.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Components/CapturedBatch.cs
@@ -17,6 +17,7 @@ namespace Duracellko.PlanningPoker.Client.Test.Components
         [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "Property is captured during rendering.")]
         public IList<RenderTreeFrame> ReferenceFrames { get; set; }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "BL0006:Do not use RenderTree types", Justification = "Demonstration only.")]
         internal void AddDiff(RenderTreeDiff diff)
         {
             var componentId = diff.ComponentId;

--- a/test/Duracellko.PlanningPoker.Client.Test/Components/TestRenderer.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Components/TestRenderer.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Duracellko.PlanningPoker.Client.Test.Components
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "BL0006:Do not use RenderTree types", Justification = "Demonstration only.")]
     public class TestRenderer : Renderer
     {
         public TestRenderer(IServiceProvider serviceProvider)

--- a/test/Duracellko.PlanningPoker.Client.Test/Controllers/CreateTeamControllerTest.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Controllers/CreateTeamControllerTest.cs
@@ -2,9 +2,9 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Duracellko.PlanningPoker.Client.Controllers;
+using Duracellko.PlanningPoker.Client.Service;
 using Duracellko.PlanningPoker.Client.UI;
 using Duracellko.PlanningPoker.Service;
-using Microsoft.AspNetCore.Components;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -70,12 +70,12 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
         public async Task CreateTeam_ServiceReturnsTeam_NavigatesToPlanningPoker()
         {
             var scrumTeam = PlanningPokerData.GetInitialScrumTeam();
-            var uriHelper = new Mock<IUriHelper>();
-            var target = CreateController(uriHelper: uriHelper.Object, scrumTeam: scrumTeam);
+            var navigationManager = new Mock<INavigationManager>();
+            var target = CreateController(navigationManager: navigationManager.Object, scrumTeam: scrumTeam);
 
             await target.CreateTeam(PlanningPokerData.TeamName, PlanningPokerData.ScrumMasterName);
 
-            uriHelper.Verify(o => o.NavigateTo("PlanningPoker/Test%20team/Test%20Scrum%20Master"));
+            navigationManager.Verify(o => o.NavigateTo("PlanningPoker/Test%20team/Test%20Scrum%20Master"));
         }
 
         [TestMethod]
@@ -103,13 +103,13 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
         [TestMethod]
         public async Task CreateTeam_ServiceThrowsException_DoesNotNavigateToPlanningPoker()
         {
-            var uriHelper = new Mock<IUriHelper>();
+            var navigationManager = new Mock<INavigationManager>();
 
-            var target = CreateController(uriHelper: uriHelper.Object, errorMessage: string.Empty);
+            var target = CreateController(navigationManager: navigationManager.Object, errorMessage: string.Empty);
 
             await target.CreateTeam(PlanningPokerData.TeamName, PlanningPokerData.ScrumMasterName);
 
-            uriHelper.Verify(o => o.NavigateTo(It.IsAny<string>()), Times.Never());
+            navigationManager.Verify(o => o.NavigateTo(It.IsAny<string>()), Times.Never());
         }
 
         [TestMethod]
@@ -166,7 +166,7 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
             IPlanningPokerClient planningPokerService = null,
             IMessageBoxService messageBoxService = null,
             IBusyIndicatorService busyIndicatorService = null,
-            IUriHelper uriHelper = null,
+            INavigationManager navigationManager = null,
             ScrumTeam scrumTeam = null,
             string errorMessage = null)
         {
@@ -204,13 +204,13 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
                 busyIndicatorService = busyIndicatorServiceMock.Object;
             }
 
-            if (uriHelper == null)
+            if (navigationManager == null)
             {
-                var uriHelperMock = new Mock<IUriHelper>();
-                uriHelper = uriHelperMock.Object;
+                var navigationManagerMock = new Mock<INavigationManager>();
+                navigationManager = navigationManagerMock.Object;
             }
 
-            return new CreateTeamController(planningPokerService, planningPokerInitializer, messageBoxService, busyIndicatorService, uriHelper);
+            return new CreateTeamController(planningPokerService, planningPokerInitializer, messageBoxService, busyIndicatorService, navigationManager);
         }
     }
 }

--- a/test/Duracellko.PlanningPoker.Client.Test/Controllers/JoinTeamControllerTest.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Controllers/JoinTeamControllerTest.cs
@@ -5,7 +5,6 @@ using Duracellko.PlanningPoker.Client.Controllers;
 using Duracellko.PlanningPoker.Client.Service;
 using Duracellko.PlanningPoker.Client.UI;
 using Duracellko.PlanningPoker.Service;
-using Microsoft.AspNetCore.Components;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -84,12 +83,12 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
         public async Task JoinTeam_ServiceReturnsTeam_NavigatesToPlanningPoker()
         {
             var scrumTeam = PlanningPokerData.GetScrumTeam();
-            var uriHelper = new Mock<IUriHelper>();
-            var target = CreateController(uriHelper: uriHelper.Object, scrumTeam: scrumTeam);
+            var navigationManager = new Mock<INavigationManager>();
+            var target = CreateController(navigationManager: navigationManager.Object, scrumTeam: scrumTeam);
 
             await target.JoinTeam(PlanningPokerData.TeamName, PlanningPokerData.ObserverName, true);
 
-            uriHelper.Verify(o => o.NavigateTo("PlanningPoker/Test%20team/Test%20observer"));
+            navigationManager.Verify(o => o.NavigateTo("PlanningPoker/Test%20team/Test%20observer"));
         }
 
         [TestMethod]
@@ -117,13 +116,13 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
         [TestMethod]
         public async Task JoinTeam_ServiceThrowsException_DoesNotNavigateToPlanningPoker()
         {
-            var uriHelper = new Mock<IUriHelper>();
+            var navigationManager = new Mock<INavigationManager>();
 
-            var target = CreateController(uriHelper: uriHelper.Object, errorMessage: ErrorMessage);
+            var target = CreateController(navigationManager: navigationManager.Object, errorMessage: ErrorMessage);
 
             await target.JoinTeam(PlanningPokerData.TeamName, PlanningPokerData.MemberName, false);
 
-            uriHelper.Verify(o => o.NavigateTo(It.IsAny<string>()), Times.Never());
+            navigationManager.Verify(o => o.NavigateTo(It.IsAny<string>()), Times.Never());
         }
 
         [TestMethod]
@@ -240,12 +239,12 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
         public async Task ReconnectTeam_ServiceReturnsTeam_NavigatesToPlanningPoker()
         {
             var reconnectTeamResult = PlanningPokerData.GetReconnectTeamResult();
-            var uriHelper = new Mock<IUriHelper>();
-            var target = CreateController(memberExistsError: true, uriHelper: uriHelper.Object, reconnectTeamResult: reconnectTeamResult);
+            var navigationManager = new Mock<INavigationManager>();
+            var target = CreateController(memberExistsError: true, navigationManager: navigationManager.Object, reconnectTeamResult: reconnectTeamResult);
 
             await target.JoinTeam(PlanningPokerData.TeamName, PlanningPokerData.ObserverName, true);
 
-            uriHelper.Verify(o => o.NavigateTo("PlanningPoker/Test%20team/Test%20observer"));
+            navigationManager.Verify(o => o.NavigateTo("PlanningPoker/Test%20team/Test%20observer"));
         }
 
         [TestMethod]
@@ -273,13 +272,13 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
         [TestMethod]
         public async Task ReconnectTeam_ServiceThrowsException_DoesNotNavigateToPlanningPoker()
         {
-            var uriHelper = new Mock<IUriHelper>();
+            var navigationManager = new Mock<INavigationManager>();
 
-            var target = CreateController(memberExistsError: true, uriHelper: uriHelper.Object, errorMessage: ErrorMessage);
+            var target = CreateController(memberExistsError: true, navigationManager: navigationManager.Object, errorMessage: ErrorMessage);
 
             await target.JoinTeam(PlanningPokerData.TeamName, PlanningPokerData.MemberName, false);
 
-            uriHelper.Verify(o => o.NavigateTo(It.IsAny<string>()), Times.Never());
+            navigationManager.Verify(o => o.NavigateTo(It.IsAny<string>()), Times.Never());
         }
 
         [TestMethod]
@@ -428,16 +427,16 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
         {
             var reconnectTeamResult = PlanningPokerData.GetReconnectTeamResult();
             var memberCredentials = PlanningPokerData.GetMemberCredentials();
-            var uriHelper = new Mock<IUriHelper>();
+            var navigationManager = new Mock<INavigationManager>();
             var target = CreateController(
-                uriHelper: uriHelper.Object,
+                navigationManager: navigationManager.Object,
                 memberExistsError: true,
                 reconnectTeamResult: reconnectTeamResult,
                 memberCredentials: memberCredentials);
 
             await target.TryReconnectTeam(PlanningPokerData.TeamName, PlanningPokerData.MemberName);
 
-            uriHelper.Verify(o => o.NavigateTo("PlanningPoker/Test%20team/Test%20member"));
+            navigationManager.Verify(o => o.NavigateTo("PlanningPoker/Test%20team/Test%20member"));
         }
 
         [TestMethod]
@@ -471,16 +470,16 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
         public async Task TryReconnectTeam_ServiceThrowsException_DoesNotNavigateToPlanningPoker()
         {
             var memberCredentials = PlanningPokerData.GetMemberCredentials();
-            var uriHelper = new Mock<IUriHelper>();
+            var navigationManager = new Mock<INavigationManager>();
             var target = CreateController(
-                uriHelper: uriHelper.Object,
+                navigationManager: navigationManager.Object,
                 memberExistsError: true,
                 errorMessage: ErrorMessage,
                 memberCredentials: memberCredentials);
 
             await target.TryReconnectTeam(PlanningPokerData.TeamName, PlanningPokerData.MemberName);
 
-            uriHelper.Verify(o => o.NavigateTo(It.IsAny<string>()), Times.Never());
+            navigationManager.Verify(o => o.NavigateTo(It.IsAny<string>()), Times.Never());
         }
 
         [TestMethod]
@@ -542,7 +541,7 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
             IPlanningPokerClient planningPokerService = null,
             IMessageBoxService messageBoxService = null,
             IBusyIndicatorService busyIndicatorService = null,
-            IUriHelper uriHelper = null,
+            INavigationManager navigationManager = null,
             IMemberCredentialsStore memberCredentialsStore = null,
             bool memberExistsError = false,
             ScrumTeam scrumTeam = null,
@@ -605,10 +604,10 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
                 busyIndicatorService = busyIndicatorServiceMock.Object;
             }
 
-            if (uriHelper == null)
+            if (navigationManager == null)
             {
-                var uriHelperMock = new Mock<IUriHelper>();
-                uriHelper = uriHelperMock.Object;
+                var navigationManagerMock = new Mock<INavigationManager>();
+                navigationManager = navigationManagerMock.Object;
             }
 
             if (memberCredentialsStore == null)
@@ -618,7 +617,7 @@ namespace Duracellko.PlanningPoker.Client.Test.Controllers
                 memberCredentialsStore = memberCredentialsStoreMock.Object;
             }
 
-            return new JoinTeamController(planningPokerService, planningPokerInitializer, messageBoxService, busyIndicatorService, uriHelper, memberCredentialsStore);
+            return new JoinTeamController(planningPokerService, planningPokerInitializer, messageBoxService, busyIndicatorService, navigationManager, memberCredentialsStore);
         }
 
         private static void SetupReconnectMessageBox(Mock<IMessageBoxService> messageBoxService, bool result)

--- a/test/Duracellko.PlanningPoker.Client.Test/Duracellko.PlanningPoker.Client.Test.csproj
+++ b/test/Duracellko.PlanningPoker.Client.Test/Duracellko.PlanningPoker.Client.Test.csproj
@@ -11,10 +11,10 @@
   <Import Project="..\..\src\Duracellko.PlanningPoker.Shared\Duracellko.PlanningPoker.Shared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
   </ItemGroup>
 

--- a/test/Duracellko.PlanningPoker.Domain.Test/Duracellko.PlanningPoker.Domain.Test.csproj
+++ b/test/Duracellko.PlanningPoker.Domain.Test/Duracellko.PlanningPoker.Domain.Test.csproj
@@ -10,9 +10,9 @@
   <Import Project="..\..\src\Duracellko.PlanningPoker.Shared\Duracellko.PlanningPoker.Shared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Duracellko.PlanningPoker.E2ETest/Duracellko.PlanningPoker.E2ETest.csproj
+++ b/test/Duracellko.PlanningPoker.E2ETest/Duracellko.PlanningPoker.E2ETest.csproj
@@ -10,9 +10,9 @@
   <Import Project="..\..\src\Duracellko.PlanningPoker.Shared\Duracellko.PlanningPoker.Shared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
   </ItemGroup>
 

--- a/test/Duracellko.PlanningPoker.Test/Duracellko.PlanningPoker.Test.csproj
+++ b/test/Duracellko.PlanningPoker.Test/Duracellko.PlanningPoker.Test.csproj
@@ -10,10 +10,10 @@
   <Import Project="..\..\src\Duracellko.PlanningPoker.Shared\Duracellko.PlanningPoker.Shared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Includes INavigationManager interface, because IUriHelper interface was replaced by NavigationManager class that was harder to mock.