### PR TITLE
Wrap long member name under card

### DIFF
--- a/src/Duracellko.PlanningPoker.Client/wwwroot/Content/Site.css
+++ b/src/Duracellko.PlanningPoker.Client/wwwroot/Content/Site.css
@@ -157,4 +157,5 @@ main a:focus, main a:hover, main a:not([href]):not([tabindex]):focus, main a:not
     text-align: center;
     font-size: 10pt;
     font-weight: bold;
+    overflow-wrap: break-word;
 }


### PR DESCRIPTION
Fix breaking of long member name without spaces under card