### PR TITLE
Enable to change deck without restarting the team

### DIFF
--- a/src/Duracellko.PlanningPoker.Azure/AzurePlanningPokerController.cs
+++ b/src/Duracellko.PlanningPoker.Azure/AzurePlanningPokerController.cs
@@ -317,6 +317,13 @@ namespace Duracellko.PlanningPoker.Azure
                     }
 
                     break;
+                case MessageType.AvailableEstimationsChanged:
+                    var estimationSetMessage = (EstimationSetMessage)e.Message;
+                    scrumTeamMessage = new ScrumTeamEstimationSetMessage(team.Name, estimationSetMessage.MessageType)
+                    {
+                        Estimations = estimationSetMessage.Estimations.Select(e => e.Value).ToList()
+                    };
+                    break;
                 case MessageType.TimerStarted:
                     var timerMessage = (TimerMessage)e.Message;
                     scrumTeamMessage = new ScrumTeamTimerMessage(team.Name, timerMessage.MessageType)

--- a/src/Duracellko.PlanningPoker.Azure/ScrumTeamEstimationSetMessage.cs
+++ b/src/Duracellko.PlanningPoker.Azure/ScrumTeamEstimationSetMessage.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Duracellko.PlanningPoker.Domain;
+
+namespace Duracellko.PlanningPoker.Azure
+{
+    /// <summary>
+    /// Message of event in specific Scrum team, which notifies that the collection of available estimations has changed.
+    /// </summary>
+    public class ScrumTeamEstimationSetMessage : ScrumTeamMessage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScrumTeamEstimationSetMessage"/> class.
+        /// </summary>
+        public ScrumTeamEstimationSetMessage()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScrumTeamEstimationSetMessage"/> class.
+        /// </summary>
+        /// <param name="teamName">The name of team, this message is related to.</param>
+        /// <param name="messageType">The type of message.</param>
+        public ScrumTeamEstimationSetMessage(string teamName, MessageType messageType)
+            : base(teamName, messageType)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the estimations associated to the message.
+        /// </summary>
+        /// <value>
+        /// The estimations collection.
+        /// </value>
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "Data contract has all properties read-write.")]
+        public IList<double?> Estimations { get; set; } = new List<double?>();
+    }
+}

--- a/src/Duracellko.PlanningPoker.Azure/ServiceBus/MessageConverter.cs
+++ b/src/Duracellko.PlanningPoker.Azure/ServiceBus/MessageConverter.cs
@@ -103,6 +103,10 @@ namespace Duracellko.PlanningPoker.Azure.ServiceBus
                     {
                         result.Data = ConvertFromMessageBody<ScrumTeamMemberEstimationMessage>(message.Body);
                     }
+                    else if (string.Equals(messageSubtype, typeof(ScrumTeamEstimationSetMessage).Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.Data = ConvertFromMessageBody<ScrumTeamEstimationSetMessage>(message.Body);
+                    }
                     else if (string.Equals(messageSubtype, typeof(ScrumTeamTimerMessage).Name, StringComparison.OrdinalIgnoreCase))
                     {
                         result.Data = ConvertFromMessageBody<ScrumTeamTimerMessage>(message.Body);

--- a/src/Duracellko.PlanningPoker.Client/Controllers/PlanningPokerController.cs
+++ b/src/Duracellko.PlanningPoker.Client/Controllers/PlanningPokerController.cs
@@ -538,6 +538,9 @@ namespace Duracellko.PlanningPoker.Client.Controllers
                 case MessageType.MemberEstimated:
                     OnMemberEstimated((MemberMessage)message);
                     break;
+                case MessageType.AvailableEstimationsChanged:
+                    OnAvailableEstimationsChanged((EstimationSetMessage)message);
+                    break;
                 case MessageType.TimerStarted:
                     OnTimerStarted((TimerMessage)message);
                     break;
@@ -642,6 +645,16 @@ namespace Duracellko.PlanningPoker.Client.Controllers
             {
                 _memberEstimations.Add(new MemberEstimation(memberName));
             }
+        }
+
+        private void OnAvailableEstimationsChanged(EstimationSetMessage message)
+        {
+            if (ScrumTeam == null)
+            {
+                return;
+            }
+
+            ScrumTeam.AvailableEstimations = message.Estimations;
         }
 
         private void OnTimerStarted(TimerMessage message)

--- a/src/Duracellko.PlanningPoker.Client/Service/IPlanningPokerClient.cs
+++ b/src/Duracellko.PlanningPoker.Client/Service/IPlanningPokerClient.cs
@@ -93,6 +93,17 @@ namespace Duracellko.PlanningPoker.Client.Service
         Task SubmitEstimation(string teamName, string memberName, double? estimation, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Changes deck of estimation cards, if estimation is not in progress.
+        /// </summary>
+        /// <param name="teamName">Name of the Scrum team.</param>
+        /// <param name="deck">New deck of estimation cards to use in the team.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>
+        /// Asynchronous operation.
+        /// </returns>
+        Task ChangeDeck(string teamName, Deck deck, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Starts countdown timer for team with specified duration.
         /// </summary>
         /// <param name="teamName">Name of the Scrum team.</param>

--- a/src/Duracellko.PlanningPoker.Client/Service/PlanningPokerClient.cs
+++ b/src/Duracellko.PlanningPoker.Client/Service/PlanningPokerClient.cs
@@ -185,6 +185,23 @@ namespace Duracellko.PlanningPoker.Client.Service
         }
 
         /// <summary>
+        /// Changes deck of estimation cards, if estimation is not in progress.
+        /// </summary>
+        /// <param name="teamName">Name of the Scrum team.</param>
+        /// <param name="deck">New deck of estimation cards to use in the team.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>
+        /// Asynchronous operation.
+        /// </returns>
+        public Task ChangeDeck(string teamName, Deck deck, CancellationToken cancellationToken)
+        {
+            var encodedTeamName = _urlEncoder.Encode(teamName);
+            var uri = $"ChangeDeck?teamName={encodedTeamName}&deck={deck}";
+
+            return SendAsync(uri, cancellationToken);
+        }
+
+        /// <summary>
         /// Starts countdown timer for team with specified duration.
         /// </summary>
         /// <param name="teamName">Name of the Scrum team.</param>

--- a/src/Duracellko.PlanningPoker.Client/Service/PlanningPokerSignalRClient.cs
+++ b/src/Duracellko.PlanningPoker.Client/Service/PlanningPokerSignalRClient.cs
@@ -180,6 +180,24 @@ namespace Duracellko.PlanningPoker.Client.Service
         }
 
         /// <summary>
+        /// Changes deck of estimation cards, if estimation is not in progress.
+        /// </summary>
+        /// <param name="teamName">Name of the Scrum team.</param>
+        /// <param name="deck">New deck of estimation cards to use in the team.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>
+        /// Asynchronous operation.
+        /// </returns>
+        public Task ChangeDeck(string teamName, Deck deck, CancellationToken cancellationToken)
+        {
+            return InvokeOperation(async () =>
+            {
+                var hubConnection = await EnsureConnected(cancellationToken);
+                await hubConnection.InvokeAsync("ChangeDeck", teamName, deck, cancellationToken);
+            });
+        }
+
+        /// <summary>
         /// Starts countdown timer for team with specified duration.
         /// </summary>
         /// <param name="teamName">Name of the Scrum team.</param>

--- a/src/Duracellko.PlanningPoker.Client/Service/ScrumTeamMapper.cs
+++ b/src/Duracellko.PlanningPoker.Client/Service/ScrumTeamMapper.cs
@@ -57,10 +57,16 @@ namespace Duracellko.PlanningPoker.Client.Service
 
         private static void ConvertMessage(Message message)
         {
-            if (message.Type == MessageType.EstimationEnded)
+            switch (message.Type)
             {
-                var estimationResultMessage = (EstimationResultMessage)message;
-                ConvertEstimations(estimationResultMessage.EstimationResult);
+                case MessageType.EstimationEnded:
+                    var estimationResultMessage = (EstimationResultMessage)message;
+                    ConvertEstimations(estimationResultMessage.EstimationResult);
+                    break;
+                case MessageType.AvailableEstimationsChanged:
+                    var estimationSetMessage = (EstimationSetMessage)message;
+                    ConvertEstimations(estimationSetMessage.Estimations);
+                    break;
             }
         }
 

--- a/src/Duracellko.PlanningPoker.Domain/EstimationResultMessage.cs
+++ b/src/Duracellko.PlanningPoker.Domain/EstimationResultMessage.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Duracellko.PlanningPoker.Domain
 {
@@ -15,7 +16,7 @@ namespace Duracellko.PlanningPoker.Domain
         public EstimationResultMessage(MessageType type, EstimationResult estimationResult)
             : base(type)
         {
-            EstimationResult = estimationResult;
+            EstimationResult = estimationResult ?? throw new ArgumentNullException(nameof(estimationResult));
         }
 
         /// <summary>
@@ -26,7 +27,7 @@ namespace Duracellko.PlanningPoker.Domain
         internal EstimationResultMessage(Serialization.MessageData messageData, EstimationResult estimationResult)
             : base(messageData)
         {
-            EstimationResult = estimationResult;
+            EstimationResult = estimationResult ?? throw new ArgumentNullException(nameof(estimationResult));
         }
 
         /// <summary>

--- a/src/Duracellko.PlanningPoker.Domain/EstimationSetMessage.cs
+++ b/src/Duracellko.PlanningPoker.Domain/EstimationSetMessage.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Duracellko.PlanningPoker.Domain
+{
+    /// <summary>
+    /// Message sent to all members and observers, when the collection of available estimations is changed.
+    /// </summary>
+    public class EstimationSetMessage : Message
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EstimationSetMessage"/> class.
+        /// </summary>
+        /// <param name="type">The message type.</param>
+        /// <param name="estimations">The estimation set associated to the message.</param>
+        public EstimationSetMessage(MessageType type, IEnumerable<Estimation> estimations)
+            : base(type)
+        {
+            Estimations = estimations ?? throw new ArgumentNullException(nameof(estimations));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EstimationSetMessage"/> class.
+        /// </summary>
+        /// <param name="messageData">Message serialization data.</param>
+        internal EstimationSetMessage(Serialization.MessageData messageData)
+            : base(messageData)
+        {
+            if (messageData.Estimations == null)
+            {
+                throw new ArgumentNullException(nameof(messageData));
+            }
+
+            Estimations = messageData.Estimations.ToList();
+        }
+
+        /// <summary>
+        /// Gets the collection of estimations associated to the message.
+        /// </summary>
+        /// <value>
+        /// The estimations.
+        /// </value>
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "Message is sent to client and forgotten. Client can modify it as it wants.")]
+        public IEnumerable<Estimation> Estimations { get; }
+
+        /// <summary>
+        /// Gets serialization data of the object.
+        /// </summary>
+        /// <returns>The serialization data.</returns>
+        protected internal override Serialization.MessageData GetData()
+        {
+            var result = base.GetData();
+            result.Estimations = Estimations.ToList();
+            return result;
+        }
+    }
+}

--- a/src/Duracellko.PlanningPoker.Domain/MessageType.cs
+++ b/src/Duracellko.PlanningPoker.Domain/MessageType.cs
@@ -51,6 +51,11 @@
         TeamCreated,
 
         /// <summary>
+        /// Message specifies that the set of available estimations has changed.
+        /// </summary>
+        AvailableEstimationsChanged,
+
+        /// <summary>
         /// Message specifies that a countdown timer for team has started.
         /// </summary>
         TimerStarted,

--- a/src/Duracellko.PlanningPoker.Domain/Observer.cs
+++ b/src/Duracellko.PlanningPoker.Domain/Observer.cs
@@ -241,6 +241,8 @@ namespace Duracellko.PlanningPoker.Domain
                     var estimationResult = new EstimationResult(Team, messageData.EstimationResult!);
                     estimationResult.SetReadOnly();
                     return new EstimationResultMessage(messageData, estimationResult);
+                case MessageType.AvailableEstimationsChanged:
+                    return new EstimationSetMessage(messageData);
                 case MessageType.TimerStarted:
                     return new TimerMessage(messageData);
                 default:

--- a/src/Duracellko.PlanningPoker.Domain/Resources.Designer.cs
+++ b/src/Duracellko.PlanningPoker.Domain/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Duracellko.PlanningPoker.Domain {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Available estimations cannot be changed, when estimation is in progress..
+        /// </summary>
+        internal static string Error_ChangeAvailableEstimationsInProgress {
+            get {
+                return ResourceManager.GetString("Error_ChangeAvailableEstimationsInProgress", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Deserialization of Scrum Team failed..
         /// </summary>
         internal static string Error_DeserializationFailed {

--- a/src/Duracellko.PlanningPoker.Domain/Resources.resx
+++ b/src/Duracellko.PlanningPoker.Domain/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Error_ChangeAvailableEstimationsInProgress" xml:space="preserve">
+    <value>Available estimations cannot be changed, when estimation is in progress.</value>
+  </data>
   <data name="Error_DeserializationFailed" xml:space="preserve">
     <value>Deserialization of Scrum Team failed.</value>
   </data>

--- a/src/Duracellko.PlanningPoker.Domain/ScrumTeam.cs
+++ b/src/Duracellko.PlanningPoker.Domain/ScrumTeam.cs
@@ -117,7 +117,7 @@ namespace Duracellko.PlanningPoker.Domain
         /// Gets the available estimations the members can pick from.
         /// </summary>
         /// <value>The collection of available estimations.</value>
-        public IEnumerable<Estimation> AvailableEstimations { get; }
+        public IEnumerable<Estimation> AvailableEstimations { get; private set; }
 
         /// <summary>
         /// Gets the current Scrum team state.
@@ -303,6 +303,28 @@ namespace Duracellko.PlanningPoker.Domain
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Changes the set of available estimations, if estimation is not in progress.
+        /// </summary>
+        /// <param name="availableEstimations">The collection of available stimations.</param>
+        public void ChangeAvailableEstimations(IEnumerable<Estimation> availableEstimations)
+        {
+            if (availableEstimations == null)
+            {
+                throw new ArgumentNullException(nameof(availableEstimations));
+            }
+
+            if (State == TeamState.EstimationInProgress)
+            {
+                throw new InvalidOperationException(Resources.Error_ChangeAvailableEstimationsInProgress);
+            }
+
+            AvailableEstimations = availableEstimations;
+
+            var recipients = UnionMembersAndObservers();
+            SendMessage(recipients, () => new EstimationSetMessage(MessageType.AvailableEstimationsChanged, availableEstimations));
         }
 
         /// <summary>

--- a/src/Duracellko.PlanningPoker.Domain/Serialization/MessageData.cs
+++ b/src/Duracellko.PlanningPoker.Domain/Serialization/MessageData.cs
@@ -31,6 +31,12 @@ namespace Duracellko.PlanningPoker.Domain.Serialization
         public IDictionary<string, Estimation?>? EstimationResult { get; set; }
 
         /// <summary>
+        /// Gets or sets the collection of estimations, when type of message is Available Estimations Changed Message.
+        /// </summary>
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "All properties of data contract are read-write.")]
+        public IList<Estimation>? Estimations { get; set; }
+
+        /// <summary>
         /// Gets or sets the time in UTC time zone that specifies, when countdown ends. This is specified for Timer Started message.
         /// </summary>
         public DateTime? EndTime { get; set; }

--- a/src/Duracellko.PlanningPoker.Redis/RedisMessageConverter.cs
+++ b/src/Duracellko.PlanningPoker.Redis/RedisMessageConverter.cs
@@ -90,6 +90,10 @@ namespace Duracellko.PlanningPoker.Redis
                     {
                         result.Data = ReadObject<ScrumTeamMemberEstimationMessage>(data);
                     }
+                    else if (string.Equals(messageSubtype, typeof(ScrumTeamEstimationSetMessage).Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.Data = ReadObject<ScrumTeamEstimationSetMessage>(data);
+                    }
                     else if (string.Equals(messageSubtype, typeof(ScrumTeamTimerMessage).Name, StringComparison.OrdinalIgnoreCase))
                     {
                         result.Data = ReadObject<ScrumTeamTimerMessage>(data);

--- a/src/Duracellko.PlanningPoker.Service/EstimationSetMessage.cs
+++ b/src/Duracellko.PlanningPoker.Service/EstimationSetMessage.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Duracellko.PlanningPoker.Service
+{
+    /// <summary>
+    /// Message sent to all members and observers, when the collection of available estimations is changed.
+    /// </summary>
+    public class EstimationSetMessage : Message
+    {
+        /// <summary>
+        /// Gets or sets the estimations associated to the message.
+        /// </summary>
+        /// <value>
+        /// The estimations collection.
+        /// </value>
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "Data contract has all properties read-write.")]
+        public IList<Estimation> Estimations { get; set; } = new List<Estimation>();
+    }
+}

--- a/src/Duracellko.PlanningPoker.Service/MessageType.cs
+++ b/src/Duracellko.PlanningPoker.Service/MessageType.cs
@@ -41,6 +41,11 @@
         MemberEstimated,
 
         /// <summary>
+        /// Message specifies that the set of available estimations has changed.
+        /// </summary>
+        AvailableEstimationsChanged,
+
+        /// <summary>
         /// Message specifies that a countdown timer for team has started.
         /// </summary>
         TimerStarted,

--- a/src/Duracellko.PlanningPoker.Service/Serialization/MessageJsonConverter.cs
+++ b/src/Duracellko.PlanningPoker.Service/Serialization/MessageJsonConverter.cs
@@ -95,6 +95,11 @@ namespace Duracellko.PlanningPoker.Service.Serialization
                 writer.WritePropertyName(GetPropertyName(nameof(EstimationResultMessage.EstimationResult), options));
                 JsonSerializer.Serialize(writer, estimationResultMessage.EstimationResult, options);
             }
+            else if (value is EstimationSetMessage estimationSetMessage)
+            {
+                writer.WritePropertyName(GetPropertyName(nameof(EstimationSetMessage.Estimations), options));
+                JsonSerializer.Serialize(writer, estimationSetMessage.Estimations, options);
+            }
             else if (value is TimerMessage timerMessage)
             {
                 writer.WritePropertyName(GetPropertyName(nameof(TimerMessage.EndTime), options));
@@ -143,6 +148,15 @@ namespace Duracellko.PlanningPoker.Service.Serialization
 
                     message = estimationResultMessage;
                     break;
+                case MessageType.AvailableEstimationsChanged:
+                    var estimationSetMessage = new EstimationSetMessage();
+                    if (messageData.Estimations != null)
+                    {
+                        estimationSetMessage.Estimations = messageData.Estimations;
+                    }
+
+                    message = estimationSetMessage;
+                    break;
                 case MessageType.TimerStarted:
                     message = new TimerMessage
                     {
@@ -177,6 +191,10 @@ namespace Duracellko.PlanningPoker.Service.Serialization
             {
                 messageData.EstimationResult = JsonSerializer.Deserialize<IList<EstimationResultItem>>(ref reader, options);
             }
+            else if (IsPropertyName(ref reader, nameof(EstimationSetMessage.Estimations), options))
+            {
+                messageData.Estimations = JsonSerializer.Deserialize<IList<Estimation>>(ref reader, options);
+            }
             else if (IsPropertyName(ref reader, nameof(TimerMessage.EndTime), options))
             {
                 messageData.EndTimer = JsonSerializer.Deserialize<DateTime>(ref reader, options);
@@ -196,6 +214,8 @@ namespace Duracellko.PlanningPoker.Service.Serialization
             public TeamMember? Member { get; set; }
 
             public IList<EstimationResultItem>? EstimationResult { get; set; }
+
+            public IList<Estimation>? Estimations { get; set; }
 
             public DateTime EndTimer { get; set; }
         }

--- a/src/Duracellko.PlanningPoker/Service/PlanningPokerHubLogger.cs
+++ b/src/Duracellko.PlanningPoker/Service/PlanningPokerHubLogger.cs
@@ -42,6 +42,11 @@ namespace Duracellko.PlanningPoker.Service
             new EventId(BaseEventId + 7, nameof(SubmitEstimation)),
             "{Action}(\"{TeamName}\", \"{MemberName}\", {Estimation})");
 
+        private static readonly Action<ILogger, string, string, Deck, Exception?> _changeDeck = LoggerMessage.Define<string, string, Deck>(
+            LogLevel.Information,
+            new EventId(BaseEventId + 12, nameof(ChangeDeck)),
+            "{Action}(\"{TeamName}\", {Deck})");
+
         private static readonly Action<ILogger, string, string, string, TimeSpan, Exception?> _startTimer = LoggerMessage.Define<string, string, string, TimeSpan>(
             LogLevel.Information,
             new EventId(BaseEventId + 10, nameof(StartTimer)),
@@ -95,6 +100,11 @@ namespace Duracellko.PlanningPoker.Service
         public static void SubmitEstimation(this ILogger logger, string teamName, string memberName, double? estimation)
         {
             _submitEstimation(logger, nameof(SubmitEstimation), teamName, memberName, estimation, null);
+        }
+
+        public static void ChangeDeck(this ILogger logger, string teamName, Deck deck)
+        {
+            _changeDeck(logger, nameof(ChangeDeck), teamName, deck, null);
         }
 
         public static void StartTimer(this ILogger logger, string teamName, string memberName, TimeSpan duration)

--- a/src/Duracellko.PlanningPoker/Service/ServiceEntityMapper.cs
+++ b/src/Duracellko.PlanningPoker/Service/ServiceEntityMapper.cs
@@ -67,10 +67,12 @@ namespace Duracellko.PlanningPoker.Service
                 config.CreateMap<D.Message, Message>()
                     .Include<D.MemberMessage, MemberMessage>()
                     .Include<D.EstimationResultMessage, EstimationResultMessage>()
+                    .Include<D.EstimationSetMessage, EstimationSetMessage>()
                     .Include<D.TimerMessage, TimerMessage>()
                     .ForMember(m => m.Type, mc => mc.MapFrom(m => m.MessageType));
                 config.CreateMap<D.MemberMessage, MemberMessage>();
                 config.CreateMap<D.EstimationResultMessage, EstimationResultMessage>();
+                config.CreateMap<D.EstimationSetMessage, EstimationSetMessage>();
                 config.CreateMap<D.TimerMessage, TimerMessage>();
                 config.CreateMap<KeyValuePair<D.Member, D.Estimation>, EstimationResultItem>()
                     .ForMember(i => i.Member, mc => mc.MapFrom(p => p.Key))

--- a/test/Duracellko.PlanningPoker.Azure.Test/AzurePlanningPokerControllerTest.cs
+++ b/test/Duracellko.PlanningPoker.Azure.Test/AzurePlanningPokerControllerTest.cs
@@ -183,6 +183,31 @@ namespace Duracellko.PlanningPoker.Azure.Test
         }
 
         [TestMethod]
+        public void ObservableMessages_AvailableEstimationsChanged_ScrumTeamEstimationSetMessage()
+        {
+            // Arrange
+            var target = CreateAzurePlanningPokerController();
+            target.EndInitialization();
+            var messages = new List<ScrumTeamMessage>();
+            var teamLock = target.CreateScrumTeam("test", "master", Deck.Standard);
+            var deck = DeckProvider.Default.GetDeck(Deck.Fibonacci);
+
+            // Act
+            target.ObservableMessages.Subscribe(m => messages.Add(m));
+            teamLock.Team.ChangeAvailableEstimations(deck);
+            target.Dispose();
+
+            // Verify
+            Assert.AreEqual<int>(1, messages.Count);
+            Assert.AreEqual<MessageType>(MessageType.AvailableEstimationsChanged, messages[0].MessageType);
+            Assert.AreEqual<string>("test", messages[0].TeamName);
+            Assert.IsInstanceOfType(messages[0], typeof(ScrumTeamEstimationSetMessage));
+            var estimationSetMessage = (ScrumTeamEstimationSetMessage)messages[0];
+            var expectedEstimations = new double?[] { 0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, double.PositiveInfinity, null };
+            CollectionAssert.AreEqual(expectedEstimations, estimationSetMessage.Estimations.ToList());
+        }
+
+        [TestMethod]
         public void ObservableMessages_TimerStarted_ScrumTeamTimerMessage()
         {
             // Arrange

--- a/test/Duracellko.PlanningPoker.Azure.Test/ServiceBus/MessageConverterTest.cs
+++ b/test/Duracellko.PlanningPoker.Azure.Test/ServiceBus/MessageConverterTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using Azure.Messaging.ServiceBus;
 using Duracellko.PlanningPoker.Azure.ServiceBus;
@@ -99,6 +100,28 @@ namespace Duracellko.PlanningPoker.Azure.Test.ServiceBus
             Assert.AreEqual(TeamName, resultData.TeamName);
             Assert.AreEqual(scrumTeamMessage.MemberName, resultData.MemberName);
             Assert.AreEqual(scrumTeamMessage.Estimation, resultData.Estimation);
+        }
+
+        [TestMethod]
+        public void ConvertToServiceBusMessageAndBack_ScrumTeamEstimationSetMessage()
+        {
+            var deck = DeckProvider.Default.GetDefaultDeck().Select(e => e.Value).ToList();
+            var scrumTeamMessage = new ScrumTeamEstimationSetMessage(TeamName, MessageType.AvailableEstimationsChanged)
+            {
+                Estimations = deck
+            };
+            var nodeMessage = new NodeMessage(NodeMessageType.ScrumTeamMessage)
+            {
+                SenderNodeId = SenderId,
+                Data = scrumTeamMessage
+            };
+
+            var result = ConvertToServiceBusMessageAndBack(nodeMessage);
+            var resultData = (ScrumTeamEstimationSetMessage)result.Data!;
+
+            Assert.AreEqual(MessageType.AvailableEstimationsChanged, resultData.MessageType);
+            Assert.AreEqual(TeamName, resultData.TeamName);
+            CollectionAssert.AreEqual(deck, resultData.Estimations.ToList());
         }
 
         [TestMethod]

--- a/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerClientData.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerClientData.cs
@@ -309,11 +309,48 @@ namespace Duracellko.PlanningPoker.Client.Test.Service
 }";
         }
 
-        public static string GetTimerStartedMessageJson(string id = "0")
+        public static string GetAvailableEstimationsChangedMessageJson(string id = "0")
         {
             return @"{
             ""id"": " + id + @",
             ""type"": 7,
+            ""estimations"": [
+                {
+                    ""value"": 0
+                },
+                {
+                    ""value"": 0.5
+                },
+                {
+                    ""value"": 1
+                },
+                {
+                    ""value"": 2
+                },
+                {
+                    ""value"": 3
+                },
+                {
+                    ""value"": 5
+                },
+                {
+                    ""value"": 100
+                },
+                {
+                    ""value"": -1111100
+                },
+                {
+                    ""value"": null
+                }
+            ]
+}";
+        }
+
+        public static string GetTimerStartedMessageJson(string id = "0")
+        {
+            return @"{
+            ""id"": " + id + @",
+            ""type"": 8,
             ""endTime"": ""2021-11-17T10:03:46Z""
 }";
         }

--- a/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerClientTest.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerClientTest.cs
@@ -800,6 +800,22 @@ namespace Duracellko.PlanningPoker.Client.Test.Service
             httpMock.VerifyNoOutstandingExpectation();
         }
 
+        [DataTestMethod]
+        [DataRow(Deck.Standard, nameof(Deck.Standard))]
+        [DataRow(Deck.Rating, nameof(Deck.Rating))]
+        [DataRow(Deck.Tshirt, nameof(Deck.Tshirt))]
+        public async Task ChangeDeck_SelectedDeck_InvocationMessageIsSent(Deck deck, string deckValue)
+        {
+            var httpMock = new MockHttpMessageHandler();
+            httpMock.Expect(BaseUrl + $"api/PlanningPokerService/ChangeDeck?teamName={PlanningPokerClientData.TeamName}&deck={deckValue}")
+                .Respond(TextType, string.Empty);
+            var target = CreatePlanningPokerClient(httpMock);
+
+            await target.ChangeDeck(PlanningPokerClientData.TeamName, deck, CancellationToken.None);
+
+            httpMock.VerifyNoOutstandingExpectation();
+        }
+
         [TestMethod]
         public async Task StartTimer_TeamNameAndDuration_RequestsStartEstimationUrl()
         {

--- a/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerClientTestMessages.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerClientTestMessages.cs
@@ -194,6 +194,34 @@ namespace Duracellko.PlanningPoker.Client.Test.Service
         }
 
         [TestMethod]
+        public async Task GetMessages_TeamAndMemberName_ReturnsAvailableEstimationsChangedMessage()
+        {
+            var messageJson = PlanningPokerClientData.GetAvailableEstimationsChangedMessageJson("8");
+            var httpMock = new MockHttpMessageHandler();
+            httpMock.When(PlanningPokerClientTest.BaseUrl + $"api/PlanningPokerService/GetMessages")
+                .Respond(PlanningPokerClientTest.JsonType, PlanningPokerClientData.GetMessagesJson(messageJson));
+            var target = PlanningPokerClientTest.CreatePlanningPokerClient(httpMock);
+
+            var result = await target.GetMessages(PlanningPokerClientData.TeamName, PlanningPokerClientData.MemberName, Guid.NewGuid(), 0, CancellationToken.None);
+
+            Assert.AreEqual(1, result.Count);
+            Assert.IsInstanceOfType(result[0], typeof(EstimationSetMessage));
+            var message = (EstimationSetMessage)result[0];
+            Assert.AreEqual(8, message.Id);
+            Assert.AreEqual(MessageType.AvailableEstimationsChanged, message.Type);
+            var estimations = message.Estimations;
+            Assert.AreEqual(0.0, estimations[0].Value);
+            Assert.AreEqual(0.5, estimations[1].Value);
+            Assert.AreEqual(1.0, estimations[2].Value);
+            Assert.AreEqual(2.0, estimations[3].Value);
+            Assert.AreEqual(3.0, estimations[4].Value);
+            Assert.AreEqual(5.0, estimations[5].Value);
+            Assert.AreEqual(100.0, estimations[6].Value);
+            Assert.IsTrue(double.IsPositiveInfinity(estimations[7].Value!.Value));
+            Assert.IsNull(estimations[8].Value);
+        }
+
+        [TestMethod]
         public async Task GetMessages_TeamAndMemberName_ReturnsTimerStartedMessage()
         {
             var messageJson = PlanningPokerClientData.GetTimerStartedMessageJson("1");

--- a/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerSignalRClientTest.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerSignalRClientTest.cs
@@ -531,6 +531,28 @@ namespace Duracellko.PlanningPoker.Client.Test.Service
             await resultTask;
         }
 
+        [DataTestMethod]
+        [DataRow(Deck.Standard)]
+        [DataRow(Deck.Rating)]
+        [DataRow(Deck.Tshirt)]
+        public async Task ChangeDeck_SelectedDeck_InvocationMessageIsSent(Deck deck)
+        {
+            await using var fixture = new PlanningPokerSignalRClientFixture();
+
+            var resultTask = fixture.Target.ChangeDeck(PlanningPokerData.TeamName, deck, fixture.CancellationToken);
+
+            var sentMessage = await fixture.GetSentMessage();
+            var sentInvocationMessage = AssertIsInvocationMessage(sentMessage);
+            Assert.AreEqual("ChangeDeck", sentInvocationMessage.Target);
+            var expectedArguments = new object?[] { PlanningPokerData.TeamName, deck };
+            CollectionAssert.AreEqual(expectedArguments, sentInvocationMessage.Arguments);
+
+            var returnMessage = new CompletionMessage(sentInvocationMessage.InvocationId!, null, null, false);
+            await fixture.ReceiveMessage(returnMessage);
+
+            await resultTask;
+        }
+
         [TestMethod]
         public async Task StartTimer_TeamNameAndDuration_InvocationMessageIsSent()
         {

--- a/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerSignalRClientTestMessages.cs
+++ b/test/Duracellko.PlanningPoker.Client.Test/Service/PlanningPokerSignalRClientTestMessages.cs
@@ -196,6 +196,48 @@ namespace Duracellko.PlanningPoker.Client.Test.Service
         }
 
         [TestMethod]
+        public async Task GetMessages_TeamAndMemberName_ReturnsAvailableEstimationsChangedMessage()
+        {
+            await using var fixture = new PlanningPokerSignalRClientFixture();
+
+            var resultTask = fixture.Target.GetMessages(PlanningPokerData.TeamName, PlanningPokerData.MemberName, PlanningPokerData.SessionId, 0, fixture.CancellationToken);
+
+            var message = new EstimationSetMessage
+            {
+                Id = 22,
+                Type = MessageType.AvailableEstimationsChanged,
+                Estimations = new List<Estimation>
+                {
+                    new Estimation { Value = 0 },
+                    new Estimation { Value = 0.5 },
+                    new Estimation { Value = 1 },
+                    new Estimation { Value = 2 },
+                    new Estimation { Value = 3 },
+                    new Estimation { Value = 5 },
+                    new Estimation { Value = 100 },
+                    new Estimation { Value = Estimation.PositiveInfinity },
+                    new Estimation()
+                }
+            };
+            await ProvideMessages(fixture, message);
+
+            var result = await resultTask;
+            await Task.Yield();
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(message, result[0]);
+            var estimations = ((EstimationSetMessage)result[0]).Estimations;
+            Assert.AreEqual(0.0, estimations[0].Value);
+            Assert.AreEqual(0.5, estimations[1].Value);
+            Assert.AreEqual(1.0, estimations[2].Value);
+            Assert.AreEqual(2.0, estimations[3].Value);
+            Assert.AreEqual(3.0, estimations[4].Value);
+            Assert.AreEqual(5.0, estimations[5].Value);
+            Assert.AreEqual(100.0, estimations[6].Value);
+            Assert.IsTrue(double.IsPositiveInfinity(estimations[7].Value!.Value));
+            Assert.IsNull(estimations[8].Value);
+        }
+
+        [TestMethod]
         public async Task GetMessages_TeamAndMemberName_ReturnsTimerStartedMessage()
         {
             await using var fixture = new PlanningPokerSignalRClientFixture();

--- a/test/Duracellko.PlanningPoker.Domain.Test/EstimationResultMessageTest.cs
+++ b/test/Duracellko.PlanningPoker.Domain.Test/EstimationResultMessageTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Duracellko.PlanningPoker.Domain.Test
@@ -19,6 +20,16 @@ namespace Duracellko.PlanningPoker.Domain.Test
             // Verify
             Assert.AreEqual<MessageType>(type, result.MessageType);
             Assert.AreEqual<EstimationResult>(estimationResult, result.EstimationResult);
+        }
+
+        [TestMethod]
+        public void Constructor_EstimationResultIsNull_ArgumentNullException()
+        {
+            // Arrange
+            var type = MessageType.EstimationEnded;
+
+            // Act
+            Assert.ThrowsException<ArgumentNullException>(() => new EstimationResultMessage(type, null!));
         }
     }
 }

--- a/test/Duracellko.PlanningPoker.Domain.Test/EstimationSetMessageTest.cs
+++ b/test/Duracellko.PlanningPoker.Domain.Test/EstimationSetMessageTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Duracellko.PlanningPoker.Domain.Test
+{
+    [TestClass]
+    public class EstimationSetMessageTest
+    {
+        [TestMethod]
+        public void Constructor_TypeSpecified_MessageTypeIsSet()
+        {
+            // Arrange
+            var type = MessageType.AvailableEstimationsChanged;
+            var estimations = DeckProvider.Default.GetDefaultDeck();
+
+            // Act
+            var result = new EstimationSetMessage(type, estimations);
+
+            // Verify
+            Assert.AreEqual(type, result.MessageType);
+            Assert.AreEqual(estimations, result.Estimations);
+        }
+
+        [TestMethod]
+        public void Constructor_EstimationSetIsNull_ArgumentNullException()
+        {
+            // Arrange
+            var type = MessageType.AvailableEstimationsChanged;
+
+            // Act
+            Assert.ThrowsException<ArgumentNullException>(() => new EstimationSetMessage(type, null!));
+        }
+    }
+}

--- a/test/Duracellko.PlanningPoker.Domain.Test/ScrumTeamAsserts.cs
+++ b/test/Duracellko.PlanningPoker.Domain.Test/ScrumTeamAsserts.cs
@@ -111,6 +111,11 @@ namespace Duracellko.PlanningPoker.Domain.Test
                 AssertEstimationResultMessagesAreEqual(expectedEstimationResultMessage, (EstimationResultMessage)actual);
             }
 
+            if (expected is EstimationSetMessage expectedEstimationSetMessage)
+            {
+                AssertEstimationSetMessagesAreEqual(expectedEstimationSetMessage, (EstimationSetMessage)actual);
+            }
+
             if (expected is TimerMessage expectedTimerMessage)
             {
                 AssertTimerMessagesAreEqual(expectedTimerMessage, (TimerMessage)actual);
@@ -125,6 +130,11 @@ namespace Duracellko.PlanningPoker.Domain.Test
         private static void AssertEstimationResultMessagesAreEqual(EstimationResultMessage expected, EstimationResultMessage actual)
         {
             AssertEstimationResultsAreEqual(expected.EstimationResult, actual.EstimationResult);
+        }
+
+        private static void AssertEstimationSetMessagesAreEqual(EstimationSetMessage expected, EstimationSetMessage actual)
+        {
+            CollectionAssert.AreEqual(expected.Estimations.ToList(), actual.Estimations.ToList());
         }
 
         private static void AssertTimerMessagesAreEqual(TimerMessage expected, TimerMessage actual)

--- a/test/Duracellko.PlanningPoker.Domain.Test/ScrumTeamTest.cs
+++ b/test/Duracellko.PlanningPoker.Domain.Test/ScrumTeamTest.cs
@@ -1533,7 +1533,7 @@ namespace Duracellko.PlanningPoker.Domain.Test
         }
 
         [TestMethod]
-        public void ChangeAvailableEstimations_RatingDeck_ScrumTeamGotMessageEstimationStarted()
+        public void ChangeAvailableEstimations_RatingDeck_ScrumTeamGotMessageAvailableEstimationsChanged()
         {
             // Arrange
             var target = new ScrumTeam("test team");
@@ -1559,7 +1559,7 @@ namespace Duracellko.PlanningPoker.Domain.Test
         }
 
         [TestMethod]
-        public void ChangeAvailableEstimations_RatingDeck_ScrumMasterGetMessageEstimationStarted()
+        public void ChangeAvailableEstimations_RatingDeck_ScrumMasterGetMessageAvailableEstimationsChanged()
         {
             // Arrange
             var target = new ScrumTeam("test team");
@@ -1601,7 +1601,7 @@ namespace Duracellko.PlanningPoker.Domain.Test
         }
 
         [TestMethod]
-        public void ChangeAvailableEstimations_CustomEstimationDeck_MemberGetMessageEstimationStarted()
+        public void ChangeAvailableEstimations_CustomEstimationDeck_MemberGetMessageAvailableEstimationsChanged()
         {
             // Arrange
             var target = new ScrumTeam("test team");
@@ -1643,7 +1643,7 @@ namespace Duracellko.PlanningPoker.Domain.Test
         }
 
         [TestMethod]
-        public void ChangeAvailableEstimations_DefaultEstimationDeck_ObserverGetMessageEstimationStarted()
+        public void ChangeAvailableEstimations_DefaultEstimationDeck_ObserverGetMessageAvailableEstimationsChanged()
         {
             // Arrange
             var target = new ScrumTeam("test team");

--- a/test/Duracellko.PlanningPoker.Domain.Test/Serialization/ScrumTeamSerializerTest.cs
+++ b/test/Duracellko.PlanningPoker.Domain.Test/Serialization/ScrumTeamSerializerTest.cs
@@ -219,6 +219,23 @@ namespace Duracellko.PlanningPoker.Domain.Test.Serialization
         }
 
         [TestMethod]
+        public void SerializeAndDeserialize_AvailableEstimationsAreChanged_CopyOfTheTeam()
+        {
+            // Arrange
+            var team = new ScrumTeam("test");
+            var master = team.SetScrumMaster("master");
+            team.Join("member", false);
+            team.Join("observer", true);
+            master.StartEstimation();
+            master.CancelEstimation();
+            team.ChangeAvailableEstimations(DeckProvider.Default.GetDeck(Deck.RockPaperScissorsLizardSpock));
+
+            // Act
+            // Verify
+            VerifySerialization(team);
+        }
+
+        [TestMethod]
         public void SerializeAndDeserialize_TimerStarted_CopyOfTheTeam()
         {
             // Arrange

--- a/test/Duracellko.PlanningPoker.Redis.Test/RedisMessageConverterTest.cs
+++ b/test/Duracellko.PlanningPoker.Redis.Test/RedisMessageConverterTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using Duracellko.PlanningPoker.Azure;
 using Duracellko.PlanningPoker.Domain;
@@ -106,6 +107,28 @@ namespace Duracellko.PlanningPoker.Redis.Test
             Assert.AreEqual(TeamName, resultData.TeamName);
             Assert.AreEqual(scrumTeamMessage.MemberName, resultData.MemberName);
             Assert.AreEqual(scrumTeamMessage.Estimation, resultData.Estimation);
+        }
+
+        [TestMethod]
+        public void ConvertToRedisBusMessageAndBack_ScrumTeamEstimationSetMessage()
+        {
+            var deck = DeckProvider.Default.GetDefaultDeck().Select(e => e.Value).ToList();
+            var scrumTeamMessage = new ScrumTeamEstimationSetMessage(TeamName, MessageType.AvailableEstimationsChanged)
+            {
+                Estimations = deck
+            };
+            var nodeMessage = new NodeMessage(NodeMessageType.ScrumTeamMessage)
+            {
+                SenderNodeId = SenderId,
+                Data = scrumTeamMessage
+            };
+
+            var result = ConvertToRedisMessageAndBack(nodeMessage);
+            var resultData = (ScrumTeamEstimationSetMessage)result.Data!;
+
+            Assert.AreEqual(MessageType.AvailableEstimationsChanged, resultData.MessageType);
+            Assert.AreEqual(TeamName, resultData.TeamName);
+            CollectionAssert.AreEqual(deck, resultData.Estimations.ToList());
         }
 
         [TestMethod]

--- a/test/Duracellko.PlanningPoker.Test/Service/JsonSerializationTest.cs
+++ b/test/Duracellko.PlanningPoker.Test/Service/JsonSerializationTest.cs
@@ -369,6 +369,62 @@ namespace Duracellko.PlanningPoker.Test.Service
 
         [DataTestMethod]
         [DynamicData(nameof(JsonTestData))]
+        public void JsonSerialize_Message_AvailableEstimationsChanged(JsonSerializerDefaults jsonSerializerDefaults)
+        {
+            var message = new EstimationSetMessage
+            {
+                Id = 11,
+                Type = MessageType.AvailableEstimationsChanged,
+                Estimations = new List<Estimation>
+                {
+                    new Estimation
+                    {
+                        Value = 0
+                    },
+                    new Estimation
+                    {
+                        Value = 0.5
+                    },
+                    new Estimation
+                    {
+                        Value = 1
+                    },
+                    new Estimation
+                    {
+                        Value = 2
+                    },
+                    new Estimation
+                    {
+                        Value = 20
+                    },
+                    new Estimation
+                    {
+                        Value = Estimation.PositiveInfinity
+                    },
+                    new Estimation()
+                }
+            };
+
+            var result = SerializeAndDeserialize<Message>(message, jsonSerializerDefaults);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(message.Id, result.Id);
+            Assert.AreEqual(message.Type, result.Type);
+
+            Assert.IsInstanceOfType(result, typeof(EstimationSetMessage));
+            var estimationSetMessage = (EstimationSetMessage)result;
+            Assert.AreEqual(7, estimationSetMessage.Estimations.Count);
+            Assert.AreEqual(0.0, estimationSetMessage.Estimations[0].Value);
+            Assert.AreEqual(0.5, estimationSetMessage.Estimations[1].Value);
+            Assert.AreEqual(1.0, estimationSetMessage.Estimations[2].Value);
+            Assert.AreEqual(2.0, estimationSetMessage.Estimations[3].Value);
+            Assert.AreEqual(20.0, estimationSetMessage.Estimations[4].Value);
+            Assert.AreEqual(Estimation.PositiveInfinity, estimationSetMessage.Estimations[5].Value);
+            Assert.IsNull(estimationSetMessage.Estimations[6].Value);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(JsonTestData))]
         public void JsonSerialize_Message_TimerStarted(JsonSerializerDefaults jsonSerializerDefaults)
         {
             var message = new TimerMessage


### PR DESCRIPTION
This PR does not include UI changes. UI design is not decided yet.
However, it is possible to change deck by invoking URL.